### PR TITLE
Allow use of rest plugin version 0.3 or greater

### DIFF
--- a/PostmarkGrailsPlugin.groovy
+++ b/PostmarkGrailsPlugin.groovy
@@ -6,7 +6,7 @@ class PostmarkGrailsPlugin {
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.0.RC1 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [rest:0.3]
+    def dependsOn = [rest:0.3 > *]
 	def loadAfter = ['mail']
 	def observe = ['controllers','services']
 


### PR DESCRIPTION
Hi there, this is my first ever git interaction, so if this is the wrong way to go about this forgive me :D

I've changed the version requirement for your postmark plugin to be 0.3 or greater (current version is 0.7) as I can't deploy my application with version 0.3 of the rest plugin

As far as I can tell this works - I have not written or modified any tests to verify that though

Cheers
Steve
